### PR TITLE
Disable repeating last data from FakeGato to Eve app when no data from sensor

### DIFF
--- a/sensor.js
+++ b/sensor.js
@@ -294,7 +294,8 @@ Rtl433Accessory.prototype = {
         this.sensorService.log = this.log;
         this.loggingService = new FakeGatoHistoryService("weather", this.sensorService, {
           storage: this.storage,
-          minutes: this.refresh * 10 / 60
+          minutes: this.refresh * 10 / 60,
+          disableRepeatLastData: true
         });
         if (this.alarm !== undefined) {
           this.alarmService = new Service.ContactSensor(this.name + " Alarm");
@@ -321,7 +322,8 @@ Rtl433Accessory.prototype = {
         this.sensorService.log = this.log;
         this.loggingService = new FakeGatoHistoryService("weather", this.sensorService, {
           storage: this.storage,
-          minutes: this.refresh * 10 / 60
+          minutes: this.refresh * 10 / 60,
+          disableRepeatLastData: true
         });
         if (this.alarm !== undefined) {
           this.alarmService = new Service.ContactSensor(this.name + " Alarm");


### PR DESCRIPTION
By default [fakegato-history](https://github.com/simont77/fakegato-history)  repeats last data every 10 minute to Eve app to avoid gaps in sensor history. This is good for "lazy" sensors, but not good for normal sensors that sends data every while.

This is problem when sensor battery dies and in Eve app seems "all ok" because fakegato is filling data with last known value. (It don't respect `Error("No response")` that the timeout sets)

To avoid this behaviour i added `disableRepeatLastData` parameter for `temperature` and `humidity` sensors.