### PR TITLE
fix: allow device identification by model name

### DIFF
--- a/src/sensor.js
+++ b/src/sensor.js
@@ -81,6 +81,8 @@ function rtl433Server() {
           devices = getDevices.call(this, data.id);
         } else if (data.channel) {
           devices = getDevices.call(this, data.channel);
+        } else if (data.model) {
+          devices = getDevices.call(this, data.model);
         } else {
           this.log.error("FYI: RTL Message missing device or channel identifier.");
           this.log("Message", this.message.toString());


### PR DESCRIPTION
This PR adds support for identifying devices by their 'model' field when 'id' and 'channel' are missing in the RTL_433 JSON output. This is useful for custom decoders or devices that only report a model name.